### PR TITLE
Added patch to fix Graphite events API

### DIFF
--- a/tasks/django_events_patch.yml
+++ b/tasks/django_events_patch.yml
@@ -1,0 +1,22 @@
+#
+# Current version (0.9.12) of Graphite web views.py file uses
+# WSGIReguest.raw_post_data what have been renamed to WSGIReguest.body
+# as described here:
+# https://docs.djangoproject.com/en/dev/releases/1.4/#httprequest-raw-post-data-renamed-to-httprequest-body
+#
+# Without this patch, events API will throw error what is described here:
+# https://answers.launchpad.net/graphite/+question/241912
+#
+---
+- name: Graphite patch | get Django version
+  command: 'python -c "import django; print(django.get_version())"'
+  register: django_version
+  changed_when: False
+
+- name: Graphite patch | Rewrite views.py
+  replace:
+    dest: /usr/lib/python2.7/dist-packages/graphite/events/views.py
+    regexp: 'request\.raw_post_data'
+    replace: 'request.body'
+    backup: true
+  when: django_version.stdout | version_compare('1.4', '>')

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -49,3 +49,5 @@
   with_items:
   - "{{ apache_service }}"
   - carbon-cache
+
+- include: django_events_patch.yml


### PR DESCRIPTION
Current version of Graphite events API doesn't work with
latest Django version. This commit patches Graphite
to make the api work again.
More info here:
https://answers.launchpad.net/graphite/+question/241912
